### PR TITLE
Feature/terragrunt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.13
 
 ENV TERRAFORM_VERSION=1.9.4
 ENV AWSCLI_VERSION=1.19.73
+ENV TERRAGRUNT_VERSION=v0.62.2
 
 
 VOLUME ["/work"]
@@ -34,11 +35,8 @@ RUN apk --no-cache update && \
     rm -rf /var/tmp/ && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apk/* && \
-    wget -qO- https://github.com/gruntwork-io/terragrunt/releases/download/v0.62.2/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
-    chmod +x /usr/local/bin/terragrunt && \
-    wget -qO- https://releases.hashicorp.com/terraform/1.9.3/terraform_1.9.3_linux_amd64.zip -O /tmp/terraform.zip && \
-    unzip /tmp/terraform.zip -d /usr/local/bin && \
-    chmod +x /usr/local/bin/terraform
+    wget -qO- https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
+    chmod +x /usr/local/bin/terragrunt
 
 COPY scripts /opt/scripts
 RUN chmod 777 /opt/scripts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --no-cache update && \
     rm -rf /var/tmp/ && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apk/* && \
-    wget -qO- https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
+    wget -q https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
     chmod +x /usr/local/bin/terragrunt
 
 COPY scripts /opt/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,12 @@ RUN apk --no-cache update && \
     unzip /tmp/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
     rm -rf /var/tmp/ && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    wget -qO- https://github.com/gruntwork-io/terragrunt/releases/download/v0.62.2/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
+    chmod +x /usr/local/bin/terragrunt && \
+    wget -qO- https://releases.hashicorp.com/terraform/1.9.3/terraform_1.9.3_linux_amd64.zip -O /tmp/terraform.zip && \
+    unzip /tmp/terraform.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/terraform
 
 COPY scripts /opt/scripts
 RUN chmod 777 /opt/scripts/*


### PR DESCRIPTION
Description:

This PR adds Terragrunt to the existing Terraform Docker image. The following changes have been made:

**Added Terragrunt v0.62.2 to /usr/local/bin.**
_Details_:
Terragrunt Installation:

```
ENV TERRAGRUNT_VERSION=v0.62.2
wget -q https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
chmod +x /usr/local/bin/terragrunt
```

This update ensures that Terragrunt is available alongside Terraform in the image.